### PR TITLE
feat: Add AuthorProfile component below blog posts

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation'
 import { CustomMDX } from 'app/components/mdx'
 import { formatDate, getBlogPosts } from 'app/blog/utils'
 import { baseUrl } from 'app/sitemap'
+import { AuthorProfile } from 'app/components/AuthorProfile'
 
 export async function generateStaticParams() {
   let posts = getBlogPosts()
@@ -93,6 +94,13 @@ export default function Blog({ params }) {
       <article className="prose">
         <CustomMDX source={post.content} />
       </article>
+      <AuthorProfile
+        author={{
+          name: 'John Doe',
+          bio: 'A passionate writer and developer.',
+          avatarUrl: '/images/avatar.png',
+        }}
+      />
     </section>
   )
 }

--- a/app/components/AuthorProfile.tsx
+++ b/app/components/AuthorProfile.tsx
@@ -1,0 +1,29 @@
+import Image from 'next/image'
+
+type Author = {
+  name: string
+  bio: string
+  avatarUrl: string
+}
+
+export function AuthorProfile({ author }: { author: Author }) {
+  return (
+    <div className="flex items-center gap-4 mt-12 pt-8 border-t border-neutral-200 dark:border-neutral-700">
+      <Image
+        src={author.avatarUrl}
+        alt={author.name}
+        width={64}
+        height={64}
+        className="rounded-full object-cover"
+      />
+      <div>
+        <p className="font-bold text-neutral-900 dark:text-neutral-100">
+          {author.name}
+        </p>
+        <p className="text-sm text-neutral-600 dark:text-neutral-400">
+          {author.bio}
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
- AuthorProfile 컴포넌트 신규 생성 (app/components/AuthorProfile.tsx)
  - author prop으로 name, bio, avatarUrl 수신
  - 아바타 이미지(원형), 이름(굵게), 소개글 표시
  - Tailwind CSS로 스타일링, 다크모드 지원
- 게시글 상세 페이지(app/blog/[slug]/page.tsx)에 AuthorProfile 렌더링
  - 본문(<article>) 하단에 컴포넌트 추가
  - 임시 가짜 데이터(John Doe) 사용

Closes #7