### PR TITLE
fix: Add use client directive to AuthorProfile

### DIFF
--- a/app/components/AuthorProfile.tsx
+++ b/app/components/AuthorProfile.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 export type Author = {
   name: string
   bio: string

--- a/app/components/AuthorProfile.tsx
+++ b/app/components/AuthorProfile.tsx
@@ -26,6 +26,10 @@ function AuthorAvatar({ src, alt }: AuthorAvatarProps) {
       width={64}
       height={64}
       className="rounded-full object-cover"
+      onError={(e) => {
+        e.currentTarget.src = '/images/avatar.png'
+        e.currentTarget.onerror = null
+      }}
     />
   )
 }
@@ -46,24 +50,8 @@ function AuthorInfo({ name, bio }: AuthorInfoProps) {
 export function AuthorProfile({ author }: AuthorProfileProps) {
   return (
     <div className="flex items-center gap-4 mt-12 pt-8 border-t border-neutral-200 dark:border-neutral-700">
-      <Image
-        src={author.avatarUrl}
-        alt={author.name}
-        width={64}
-        height={64}
-        className="rounded-full object-cover"
-        onError={(e) => {
-          e.currentTarget.src = '/images/avatar.png'
-        }}
-      />
-      <div>
-        <p className="font-bold text-neutral-900 dark:text-neutral-100">
-          {author.name}
-        </p>
-        <p className="text-sm text-neutral-600 dark:text-neutral-400">
-          {author.bio}
-        </p>
-      </div>
+      <AuthorAvatar src={author.avatarUrl} alt={author.name} />
+      <AuthorInfo name={author.name} bio={author.bio} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- `AuthorProfile`의 `onError` 이벤트 핸들러가 Server Component에서 사용되어 발생하는 에러 수정
- `'use client'` 지시어 추가로 해결

## 원인

Next.js App Router에서 이벤트 핸들러(`onError` 등)는 Client Component에서만 사용 가능합니다. `AuthorProfile.tsx`에 `'use client'`가 없어 Server Component로 처리되면서 에러가 발생했습니다.

## Test plan

- [ ] 블로그 글 페이지에서 작가 프로필이 에러 없이 렌더링되는지 확인
- [ ] 잘못된 이미지 URL 시 fallback 이미지가 정상 표시되는지 확인

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)